### PR TITLE
Use new routing declaration instead of deprecated old one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "symfony/web-server-bundle": "^4.4|^5.0",
         "vimeo/psalm": "3.11.4"
     },
+    "conflict": {
+        "symplify/package-builder": "^8.3.25"
+    },
     "autoload": {
         "psr-4": {
             "Webgriffe\\SyliusTableRateShippingPlugin\\": "src/",

--- a/src/Resources/config/admin_routing.yml
+++ b/src/Resources/config/admin_routing.yml
@@ -2,8 +2,8 @@ webgriffe_sylius_table_rate_plugin_shipping_table_rate:
   resource: |
     alias: webgriffe.shipping_table_rate
     section: admin
-    templates: WebgriffeSyliusTableRateShippingPlugin:TableRateCrud
     except: ['show', 'bulkDelete']
+    templates: '@WebgriffeSyliusTableRateShippingPlugin/TableRateCrud'
     redirect: update
     grid: webgriffe_sylius_table_rate_plugin_shipping_table_rate
     vars:

--- a/src/Resources/views/TableRateCrud/_weightLimitToRateTheme.html.twig
+++ b/src/Resources/views/TableRateCrud/_weightLimitToRateTheme.html.twig
@@ -1,7 +1,7 @@
-{% extends 'SyliusAdminBundle:Form:theme.html.twig' %}
+{% extends '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block _webgriffe_sylius_table_rate_plugin_shipping_table_rate_weightLimitToRate_widget %}
-    {% from 'SyliusResourceBundle:Macros:notification.html.twig' import error %}
+    {% from '@SyliusResource/Macros/notification.html.twig' import error %}
     {% import _self as self %}
     {% set attr = attr|merge({'class': attr.class|default ~ ' controls collection-widget'}) %}
 

--- a/src/Resources/views/TableRateCrud/create.html.twig
+++ b/src/Resources/views/TableRateCrud/create.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SyliusAdminBundle:Crud:create.html.twig' %}
+{% extends '@SyliusAdmin/Crud/create.html.twig' %}
 
-{% form_theme form.weightLimitToRate 'WebgriffeSyliusTableRateShippingPlugin:TableRateCrud:_weightLimitToRateTheme.html.twig' %}
+{% form_theme form.weightLimitToRate '@WebgriffeSyliusTableRateShippingPlugin/TableRateCrud/_weightLimitToRateTheme.html.twig' %}
 

--- a/src/Resources/views/TableRateCrud/index.html.twig
+++ b/src/Resources/views/TableRateCrud/index.html.twig
@@ -1,1 +1,1 @@
-{% extends 'SyliusAdminBundle:Crud:index.html.twig' %}
+{% extends '@SyliusAdmin/Crud/index.html.twig' %}

--- a/src/Resources/views/TableRateCrud/update.html.twig
+++ b/src/Resources/views/TableRateCrud/update.html.twig
@@ -1,3 +1,3 @@
-{% extends 'SyliusAdminBundle:Crud:update.html.twig' %}
+{% extends '@SyliusAdmin/Crud/update.html.twig' %}
 
-{% form_theme form.weightLimitToRate 'WebgriffeSyliusTableRateShippingPlugin:TableRateCrud:_weightLimitToRateTheme.html.twig' %}
+{% form_theme form.weightLimitToRate '@WebgriffeSyliusTableRateShippingPlugin/TableRateCrud/_weightLimitToRateTheme.html.twig' %}


### PR DESCRIPTION
With this syntax, it is not possible to properly override some templates, and we have to override the one that calls it and the routes as well